### PR TITLE
use spawn to launch server process with multiple args

### DIFF
--- a/lib/h.js
+++ b/lib/h.js
@@ -37,6 +37,9 @@ function spawnServer (args, port) {
   var opts = { stdio: 'inherit' }
   if (os.platform() === 'win32') {
     return spawn('cmd', ['/c'].concat(args), opts)
+  } else if (args.length > 1) {
+    var cmd = args.shift()
+    return spawn(cmd, args, opts)
   } else {
     var cmd = unquote(args.join(' '))
     return spawn('sh', ['-c'].concat(cmd), opts)

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "mocha": "^2.2.1",
+    "shell-quote": "^1.4.3",
     "supertest": "^0.15.0",
     "websocket": "^1.0.17"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 var spawn = require('child_process').spawn
+var parseArgs = require('shell-quote').parse
 var supertest = require('supertest')
 var WebSocketClient = require('websocket').client
 var pkg = require('../package.json')
@@ -9,7 +10,7 @@ var webSocketClient = new WebSocketClient()
 var procs = []
 
 function h (str) {
-  var args = [__dirname + '/../' + pkg.bin.h].concat(str.split(' '))
+  var args = [__dirname + '/../' + pkg.bin.h].concat(parseArgs(str))
   var opts = {
     cwd: __dirname + '/one',
     stdio: 'inherit'


### PR DESCRIPTION
This patch changes the way server process is started when `h` receives
multiple positional arguments. 

In this case arguments have already been processed by user shell and
treating them as parts of the command string would require users to
escape arguments twice.

For example, one would need to use

```fish
$ h -- node -e 'require\\(\\"http\\"\\).createServer\\(function\\(req,res\\)\\{res.end\\(\\"hello\\"\\)\\}\\).listen\\(process.env.PORT\\)'
``` 

instead of

```fish
$ h -- node -e 'require("http").createServer().listen(process.env.PORT)'
```

With this change, arguments for commands like this are not processed the
second time and need not be escaped, and `h -- <cmd>` (single argument)
is equivalent to `h -- sh -c <cmd>`.

This fixes parts of #11 and #12 related to multiple-arguments form.